### PR TITLE
make sure to pass the current user

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ function track(key, data) {
 
 function connectStream() {
   stream.connect(function() {
-    requestor.fetchFlagSettings(user, hash, function(err, settings) {
+    requestor.fetchFlagSettings(ident.getUser(), hash, function(err, settings) {
       updateSettings(settings);
     });
   });


### PR DESCRIPTION
Found this little bug. There is no `user` in scope; it's tracked by the identity module.
