### PR TITLE
Added support for sessionStorage for cache.

### DIFF
--- a/src/__tests__/browserPlatform-test.js
+++ b/src/__tests__/browserPlatform-test.js
@@ -134,6 +134,32 @@ describe('browserPlatform', () => {
     });
   });
 
+  describe('sessionStorage', () => {
+    const plat = browserPlatform({ bootstrap: 'sessionStorage' });
+
+    // Make sure that all of the get/set tests for the localStorage tests
+    // also work with sessionStorage.
+    it('returns null or undefined for missing value', async () => {
+      const value = await plat.localStorage.get(lsKeyPrefix + 'unused-key');
+      expect(value).not.toBe(expect.anything());
+    });
+
+    it('can get and set value', async () => {
+      const key = lsKeyPrefix + 'get-set-key';
+      await plat.localStorage.set(key, 'hello');
+      const value = await plat.localStorage.get(key);
+      expect(value).toEqual('hello');
+    });
+
+    it('can delete value', async () => {
+      const key = lsKeyPrefix + 'delete-key';
+      await plat.localStorage.set(key, 'hello');
+      await plat.localStorage.clear(key);
+      const value = plat.localStorage.get(key);
+      expect(value).not.toBe(expect.anything());
+    });
+  });
+
   describe('localStorage', () => {
     // Since we're not currently running these tests in an actual browser, this is really using a
     // mock implementation of window.localStorage, but these tests still verify that our async

--- a/src/browserPlatform.js
+++ b/src/browserPlatform.js
@@ -39,20 +39,28 @@ export default function makeBrowserPlatform(options) {
   };
 
   try {
-    if (window.localStorage) {
+    // Allow the user to specify which storage type to use. If the user specifies session storage
+    // then use that. Otherwise default to local storage. Both of these implement the same
+    // storage interface, documentation here: https://developer.mozilla.org/en-US/docs/Web/API/Storage
+    const storage =
+      ((options || {}).bootstrap || '').toUpperCase() === 'SESSIONSTORAGE'
+        ? window.sessionStorage
+        : window.localStorage;
+
+    if (storage) {
       ret.localStorage = {
         get: key =>
           new Promise(resolve => {
-            resolve(window.localStorage.getItem(key));
+            resolve(storage.getItem(key));
           }),
         set: (key, value) =>
           new Promise(resolve => {
-            window.localStorage.setItem(key, value);
+            storage.setItem(key, value);
             resolve();
           }),
         clear: key =>
           new Promise(resolve => {
-            window.localStorage.removeItem(key);
+            storage.removeItem(key);
             resolve();
           }),
       };


### PR DESCRIPTION
This adds support for specifying localStorage or sessionStorage when
bootstrapping the LD JS client. This can be used if the user's hash
changes frequently and can cause a build-up of old records in the
client's local storage by instead storing data in the session storage.

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

This adds support for being able to specify `sessionStorage` when initializing the LD client. We were running into a problem where user's who were frequently signing in and out would build up several different caches for LD in local storage and had to clear them out manually. 

![image](https://user-images.githubusercontent.com/37967690/70275657-36210400-1774-11ea-87de-a9b0d4f1aa87.png)

So help improve this going forward this adds support for sessionStorage as an option for LD's cache, which will clear out cached items once the session is over rather than letting them build up.

**Describe alternatives you've considered**

This is the solution that my team and I came up with given the use case. There might be other approaches to solve the problem and I welcome any and all feedback.

**Additional context**

This merge request also has a dependency on https://github.com/launchdarkly/js-sdk-common/pull/2