### PR TITLE
Changes back to async flushes after the unload handler has completed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5426,7 +5426,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ export function initialize(env, user, options = {}) {
   const syncFlushHandler = () => {
     platform.synchronousFlush = true;
     client.flush().catch(() => {});
+    platform.synchronousFlush = false;
   };
   window.addEventListener('beforeunload', syncFlushHandler);
   window.addEventListener('unload', syncFlushHandler);


### PR DESCRIPTION
Would like to have your opinion on this change. I have not confirmed if this solves my issue. However the test cases indicates that it does solve it.
**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Potential fix for #198 

**Describe the solution you've provided**
This sets the syncFlush flag back to false after we have flushed any events that needed to be flushed during the beforeunload event.
