### PR TITLE
fix: Embedded example's instruction and JS SDK version

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -8,7 +8,7 @@ For a more realistic example of a LaunchDarkly-enabled application with both a f
 
 Most of the demo can be used without a real HTTP server; just start your browser and tell it to open the `index.html` file in this directory. The only thing that will not work in that mode is the "Set URL" feature under Navigation/Events.
 
-To access the demo via a basic HTTP server, there are several ways but the simplest-- if you have Python-- is to run `python -m SimpleHTTPServer 8000` from a command line at the SDK root directory, and then browse to this location.
+To access the demo via a basic HTTP server, there are several ways but the simplest-- if you have npx-- is to run `npx http-server` from a command line at this directory, and then browse http://127.0.0.1:8080.
 
 Note that by default, the demo uses the latest release of the JS SDK script that is hosted on `app.launchdarkly.com`. However, if it detects that you have built the SDK locally, it will use the local SDK code instead. Therefore, it can be used for testing changes to the SDK. To build from the SDK root directory, run `npm run build`.
 

--- a/example/example.js
+++ b/example/example.js
@@ -266,7 +266,7 @@ $(function() {
     $('#usingWhichScript').addClass('local');
     startDemo();
   } else {
-    var hostedScriptUrl = 'https://unpkg.com/launchdarkly-js-client-sdk@2';
+    var hostedScriptUrl = 'https://unpkg.com/launchdarkly-js-client-sdk@3';
     var script = document.createElement('script');
     script.src = hostedScriptUrl;
     script.crossOrigin = 'anonymous';

--- a/example/index.html
+++ b/example/index.html
@@ -35,7 +35,7 @@
 
       <p>
         This is a simple front-end-only application using <a href="https://launchdarkly.com/">LaunchDarkly</a>.
-        <span id="usingWhichScript">(Using <span class="hosted"><a href="https://unpkg.com/launchdarkly-js-client-sdk@2">the hosted SDK script</a></span> <span class="local">a local SDK build</span> - version <span id="sdkVersion"></span>)</span> <a href="https://docs.launchdarkly.com/sdk/client-side/javascript">Learn more</a>
+        <span id="usingWhichScript">(Using <span class="hosted"><a href="https://unpkg.com/launchdarkly-js-client-sdk@3">the hosted SDK script</a></span> <span class="local">a local SDK build</span> - version <span id="sdkVersion"></span>)</span> <a href="https://docs.launchdarkly.com/sdk/client-side/javascript">Learn more</a>
       </p>
 
       <div class="row">


### PR DESCRIPTION
Thank you @RookieRick for making a [PR](https://github.com/launchdarkly/js-client-sdk/pull/270) for this issue. After discussing with the team, we decided to go with a tool that is more common for JavaScript developers instead of relying on python.

Also fixed the imports as we had a major version upgrade recently.
