### PR TITLE
[Goal Manager] Add context as an event payload key as expected by js-sdk-common

### DIFF
--- a/src/GoalManager.js
+++ b/src/GoalManager.js
@@ -31,6 +31,7 @@ export default function GoalManager(clientVars, readyCallback) {
       url: window.location.href,
       creationDate: new Date().getTime(),
       contextKeys: common.getContextKeys(context),
+      context: context,
     };
 
     if (kind === 'click') {

--- a/src/GoalManager.js
+++ b/src/GoalManager.js
@@ -30,7 +30,6 @@ export default function GoalManager(clientVars, readyCallback) {
       data: null,
       url: window.location.href,
       creationDate: new Date().getTime(),
-      contextKeys: common.getContextKeys(context),
       context: context,
     };
 


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
  - I did not add tests since this part of the code was already untested
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions
  - I did not validate changes against supported platform versions. This is a one-line change that is non-breaking - only additive. I wanted to put this PR up to show what was wrong. 

**Related issues**

https://github.com/launchdarkly/js-client-sdk/issues/275

**Describe the solution you've provided**

- This adds `context` as a key to the event payload for goal events. js-sdk-common [does not send](https://github.com/launchdarkly/js-sdk-common/blob/main/src/index.js#L145) any events without the context key in the payload. This means all goal events are currently not being sent in the latest SDK versions. 
- I left `contextKeys` in the event payload because I wasn't sure what exactly these were doing and wanted to keep this change non-breaking and backwards compatible 

**Describe alternatives you've considered**

None

Provide a clear and concise description of any alternative solutions or features you've considered.

None 

**Additional context**

A more detailed description can be found in the linked issue. 