### PR TITLE
prepare 3.3.0 release

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -115,7 +115,7 @@ $(function() {
     client.on('change', function(allChanges) {
       showAllFlags(allChanges);
     });
-    client.waitForInitialization().then(function() { showAllFlags(); });
+    client.waitForInitialization(5).then(function() { showAllFlags(); });
   }
 
   function identifyUser() {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "escape-string-regexp": "^4.0.0",
-    "launchdarkly-js-sdk-common": "5.1.0"
+    "launchdarkly-js-sdk-common": "5.2.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "escape-string-regexp": "^4.0.0",
-    "launchdarkly-js-sdk-common": "5.0.3"
+    "launchdarkly-js-sdk-common": "5.1.0"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/LDClient-events-test.js
+++ b/src/__tests__/LDClient-events-test.js
@@ -33,7 +33,7 @@ describe('LDClient', () => {
       const client = LDClient.initialize(envName, user, { eventProcessor: ep, bootstrap: {} });
       const data = { thing: 'stuff' };
 
-      await client.waitForInitialization();
+      await client.waitForInitialization(5);
       client.track('eventkey', data);
 
       expect(ep.events.length).toEqual(2);
@@ -52,7 +52,7 @@ describe('LDClient', () => {
       const client = LDClient.initialize(envName, user, { eventProcessor: ep, bootstrap: {} });
       const data = { thing: 'stuff' };
 
-      await client.waitForInitialization();
+      await client.waitForInitialization(5);
       client.track('eventkey', data);
 
       expect(ep.events.length).toEqual(0);
@@ -67,7 +67,7 @@ describe('LDClient', () => {
         bootstrap: {},
         eventUrlTransformer: (url) => url + suffix,
       });
-      await client.waitForInitialization();
+      await client.waitForInitialization(5);
       client.track('eventkey');
 
       expect(ep.events.length).toEqual(2);

--- a/src/__tests__/LDClient-test.js
+++ b/src/__tests__/LDClient-test.js
@@ -37,19 +37,19 @@ describe('LDClient', () => {
   describe('initialization', () => {
     it('should trigger the ready event', async () => {
       const client = LDClient.initialize(envName, user, { bootstrap: {}, sendEvents: false });
-      await client.waitForInitialization();
+      await client.waitForInitialization(5);
     });
 
     it('should not fetch flag settings if bootstrap is provided, but should still fetch goals', async () => {
       const client = LDClient.initialize(envName, user, { bootstrap: {}, sendEvents: false });
-      await client.waitForInitialization();
+      await client.waitForInitialization(5);
       expect(server.requests.length).toEqual(1);
       expect(server.requests[0].url).toMatch(/sdk\/goals/);
     });
 
     it('sends correct User-Agent in request', async () => {
       const client = LDClient.initialize(envName, user, { fetchGoals: false, sendEvents: false });
-      await client.waitForInitialization();
+      await client.waitForInitialization(5);
 
       expect(server.requests.length).toEqual(1);
       expect(server.requests[0].requestHeaders['X-LaunchDarkly-User-Agent']).toMatch(/^JSClient\//);
@@ -61,7 +61,7 @@ describe('LDClient', () => {
       async function setupClient() {
         const config = { bootstrap: {}, flushInterval: 100000, fetchGoals: false, sendEvents: false };
         const client = LDClient.initialize(envName, user, config);
-        await client.waitForInitialization();
+        await client.waitForInitialization(5);
         return client;
       }
       function testWithUserAgent(desc, ua) {
@@ -91,7 +91,7 @@ describe('LDClient', () => {
   describe('goals', () => {
     it('fetches goals if fetchGoals is unspecified', async () => {
       const client = LDClient.initialize(envName, user, { sendEvents: false });
-      await client.waitForInitialization();
+      await client.waitForInitialization(5);
       expect(server.requests.length).toEqual(2);
       // The following line uses arrayContaining because we can't be sure whether the goals request will
       // be made before or after the flags request.
@@ -102,7 +102,7 @@ describe('LDClient', () => {
 
     it('fetches goals if fetchGoals is true', async () => {
       const client = LDClient.initialize(envName, user, { fetchGoals: true, sendEvents: false });
-      await client.waitForInitialization();
+      await client.waitForInitialization(5);
       expect(server.requests.length).toEqual(2);
       expect(server.requests).toEqual(
         expect.arrayContaining([expect.objectContaining({ url: expect.stringMatching(/sdk\/goals/) })])
@@ -111,7 +111,7 @@ describe('LDClient', () => {
 
     it('does not fetch goals if fetchGoals is false', async () => {
       const client = LDClient.initialize(envName, user, { fetchGoals: false, sendEvents: false });
-      await client.waitForInitialization();
+      await client.waitForInitialization(5);
       expect(server.requests.length).toEqual(1);
       expect(server.requests[0].url).toMatch(/sdk\/eval/);
     });
@@ -139,7 +139,7 @@ describe('LDClient', () => {
       server.respondWith([200, { 'Content-Type': 'application/json' }, '[{"key": "known", "kind": "custom"}]']);
 
       const client = LDClient.initialize(envName, user, { bootstrap: {}, sendEvents: false });
-      await client.waitForInitialization();
+      await client.waitForInitialization(5);
       await client.waitUntilGoalsReady();
 
       client.track('known');
@@ -151,7 +151,7 @@ describe('LDClient', () => {
       server.respondWith([200, { 'Content-Type': 'application/json' }, '[{"key": "known", "kind": "custom"}]']);
 
       const client = LDClient.initialize(envName, user, { bootstrap: {}, sendEvents: false });
-      await client.waitForInitialization();
+      await client.waitForInitialization(5);
       await client.waitUntilGoalsReady();
 
       client.track('unknown');
@@ -164,7 +164,7 @@ describe('LDClient', () => {
     it('normally uses asynchronous XHR', async () => {
       const config = { bootstrap: {}, flushInterval: 100000, fetchGoals: false, diagnosticOptOut: true };
       const client = LDClient.initialize(envName, user, config);
-      await client.waitForInitialization();
+      await client.waitForInitialization(5);
 
       await client.flush();
 
@@ -175,7 +175,7 @@ describe('LDClient', () => {
     async function setupClientAndTriggerPageHide() {
       const config = { bootstrap: {}, flushInterval: 100000, fetchGoals: false, diagnosticOptOut: true };
       const client = LDClient.initialize(envName, user, config);
-      await client.waitForInitialization();
+      await client.waitForInitialization(5);
 
       Object.defineProperty(document, 'visibilityState', {
         configurable: true,

--- a/src/__tests__/LDClient-test.js
+++ b/src/__tests__/LDClient-test.js
@@ -168,9 +168,8 @@ describe('LDClient', () => {
 
       await client.flush();
 
-      expect(server.requests.length).toEqual(2);
-      // ignore first request because it's just a side effect of calling browserPlatform.httpAllowsPost()
-      expect(server.requests[1].async).toBe(true);
+      expect(server.requests.length).toEqual(1);
+      expect(server.requests[0].async).toBe(true);
     });
 
     async function setupClientAndTriggerPageHide() {
@@ -196,9 +195,8 @@ describe('LDClient', () => {
 
           await setupClientAndTriggerPageHide();
 
-          expect(server.requests.length).toEqual(2);
-          // ignore first request because it's just a side effect of calling browserPlatform.httpAllowsPost()
-          expect(server.requests[1].async).toBe(false); // events
+          expect(server.requests.length).toEqual(1);
+          expect(server.requests[0].async).toBe(false); // events
         });
       }
 
@@ -218,13 +216,12 @@ describe('LDClient', () => {
           window.navigator.__defineGetter__('userAgent', () => ua);
 
           const client = await setupClientAndTriggerPageHide();
-          expect(server.requests.length).toEqual(2);
-          // ignore first request because it's just a side effect of calling browserPlatform.httpAllowsPost()
-          expect(server.requests[1].async).toBe(false); // events
+          expect(server.requests.length).toEqual(1);
+          expect(server.requests[0].async).toBe(false); // events
           client.track('Test'); // lets track a event that happen after a beforeunload event.
           client.flush().catch(() => {}); // flush that event
-          expect(server.requests.length).toEqual(3); // assert the server got the request.
-          expect(server.requests[2].async).toBe(true);
+          expect(server.requests.length).toEqual(2); // assert the server got the request.
+          expect(server.requests[1].async).toBe(true);
         });
       }
 
@@ -236,30 +233,6 @@ describe('LDClient', () => {
       testWithUserAgent('unknown browser', 'Special Kitty Cat Browser');
 
       testWithUserAgent('empty user-agent', null);
-    });
-
-    describe('discards events during page unload', () => {
-      function testWithUserAgent(desc, ua) {
-        it('in ' + desc, async () => {
-          window.navigator.__defineGetter__('userAgent', () => ua);
-
-          await setupClientAndTriggerPageHide();
-
-          window.dispatchEvent(new window.Event('beforeunload'));
-
-          expect(server.requests.length).toEqual(1); // flags query
-        });
-      }
-
-      testWithUserAgent(
-        'Chrome 73',
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36'
-      );
-
-      testWithUserAgent(
-        'Chrome 74',
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3683.103 Safari/537.36'
-      );
     });
   });
 });

--- a/test-types.ts
+++ b/test-types.ts
@@ -84,7 +84,7 @@ const multiKindContext: ld.LDContext = {
 const client: ld.LDClient = ld.initialize('env', user, allOptions);
 
 client.waitUntilReady().then(() => {});
-client.waitForInitialization().then(() => {});
+client.waitForInitialization(5).then(() => {});
 client.waitUntilGoalsReady().then(() => {});
 
 client.identify(user).then(() => {});


### PR DESCRIPTION
## [3.3.0] - 2024-05-01
### Added:
- Added an optional timeout to the `waitForInitialization` method. When a timeout is specified the returned promise will be rejected after the timeout elapses if the client has not finished initializing within that time. When no timeout is specified the returned promise will not be resolved or rejected until the initialization either completes or fails.

### Changed:
- The track method now validates that the provided metricValue is a number. If a metric value is provided, and it is not a number, then a warning will be logged.

### Fixed:
- Fixed the documentation for `evaluationReasons` for the `identify` method.