### PR TITLE
chore: remove release-as override that caused duplicate 3.9.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 All notable changes to the LaunchDarkly client-side JavaScript SDKs will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
-## [3.9.1](https://github.com/launchdarkly/js-client-sdk/compare/3.9.1...3.9.1) (2026-05-26)
-
-
-### Bug Fixes
-
-* update launchdarkly-js-sdk-common to 5.8.1 ([#341](https://github.com/launchdarkly/js-client-sdk/issues/341)) ([41c99a9](https://github.com/launchdarkly/js-client-sdk/commit/41c99a953454e697ac7f8fd16ba24d19198aab5b))
-
 ## [3.9.1](https://github.com/launchdarkly/js-client-sdk/compare/3.9.0...3.9.1) (2026-04-06)
 
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
     ".": {
       "release-type": "node",
       "include-v-in-tag": false,
-      "include-component-in-tag": false,
-      "release-as": "3.9.1"
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

N/A — config-only change, no application code modified.

**Related issues**

The release workflow failed because release-please created a duplicate 3.9.1 release PR (#342) when the tag already existed from the first 3.9.1 release (#333).

**Describe the solution you've provided**

Removes the `release-as: "3.9.1"` override from `release-please-config.json` that was added in #336. This override was intended as a one-time version force but was not cleaned up after the first 3.9.1 release shipped. When new commits (including #341) landed on main, release-please re-used the override and created a second 3.9.1 release PR (#342), which failed because the `3.9.1` tag already existed.

Also removes the duplicate 3.9.1 CHANGELOG entry (with the broken `compare/3.9.1...3.9.1` link) that was added by #342.

After this merges, release-please will correctly compute the next version based on conventional commits since the 3.9.1 tag.

**Describe alternatives you've considered**

N/A

**Additional context**

The `fix:` commit from #341 (update launchdarkly-js-sdk-common to 5.8.1) was not included in the published 3.9.1 npm package. Once this config fix merges, release-please should create a 3.9.2 release PR that includes that change.

Link to Devin session: https://app.devin.ai/sessions/3fa824bb54c44fecb407c8aa43e3f193
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and changelog-only; no runtime SDK code changes.
> 
> **Overview**
> Fixes a **release-please** misconfiguration that caused a second **3.9.1** release PR when commits landed after the real **3.9.1** tag already existed.
> 
> The PR **removes** the leftover **`release-as: "3.9.1"`** entry from `release-please-config.json` (a one-time override that was never cleared after the first **3.9.1** shipped). It also **deletes** the erroneous duplicate **3.9.1** block from `CHANGELOG.md` (including the broken `compare/3.9.1...3.9.1` link) that came from that failed release PR.
> 
> After merge, release-please should pick the next version from conventional commits since **3.9.1** (e.g. **3.9.2** for the unreleased `js-sdk-common` bump).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28fe5fa11e93c013359a426712c99d5ba8eeca8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->