### PR TITLE
fix: goal manager bypasses event transformer

### DIFF
--- a/src/GoalManager.js
+++ b/src/GoalManager.js
@@ -3,7 +3,7 @@ import GoalTracker from './GoalTracker';
 
 const locationWatcherInterval = 300;
 
-export default function GoalManager(clientVars, readyCallback) {
+export default function GoalManager(clientVars, platform, readyCallback) {
   let goals;
   let goalTracker;
 
@@ -28,7 +28,7 @@ export default function GoalManager(clientVars, readyCallback) {
       kind: kind,
       key: goal.key,
       data: null,
-      url: window.location.href,
+      url: platform.getCurrentUrl(),
       creationDate: new Date().getTime(),
       context: context,
     };

--- a/src/__tests__/GoalManager-test.js
+++ b/src/__tests__/GoalManager-test.js
@@ -1,0 +1,62 @@
+import GoalManager from '../GoalManager';
+import browserPlatform from '../browserPlatform';
+
+describe('GoalManager', () => {
+  function makeClientVars(goals, enqueueEvent) {
+    return {
+      getEnvironmentId: () => 'env-id',
+      ident: { getContext: () => ({ key: 'user' }) },
+      enqueueEvent,
+      requestor: { fetchJSON: () => Promise.resolve(goals) },
+    };
+  }
+
+  function makeGoals() {
+    return [
+      {
+        key: 'pageview-goal',
+        kind: 'pageview',
+        urls: [{ kind: 'substring', substring: 'mydomain' }],
+      },
+      {
+        key: 'click-goal',
+        kind: 'click',
+        selector: '.does-not-match-anything',
+        urls: [{ kind: 'substring', substring: 'mydomain' }],
+      },
+    ];
+  }
+
+  it('applies eventUrlTransformer to synthesized pageview and click_pageview events', async () => {
+    const suffix = '/transformed';
+    const platform = browserPlatform({ eventUrlTransformer: (url) => url + suffix });
+    const enqueued = [];
+    const clientVars = makeClientVars(makeGoals(), (e) => enqueued.push(e));
+
+    await new Promise((resolve) => {
+      GoalManager(clientVars, platform, resolve);
+    });
+
+    const pageview = enqueued.find((e) => e.kind === 'pageview');
+    const clickPageview = enqueued.find((e) => e.kind === 'click_pageview');
+
+    expect(pageview).toBeDefined();
+    expect(pageview.url).toEqual(window.location.href + suffix);
+    expect(clickPageview).toBeDefined();
+    expect(clickPageview.url).toEqual(window.location.href + suffix);
+  });
+
+  it('leaves the URL untransformed when no eventUrlTransformer is configured', async () => {
+    const platform = browserPlatform({});
+    const enqueued = [];
+    const clientVars = makeClientVars(makeGoals(), (e) => enqueued.push(e));
+
+    await new Promise((resolve) => {
+      GoalManager(clientVars, platform, resolve);
+    });
+
+    const pageview = enqueued.find((e) => e.kind === 'pageview');
+    expect(pageview).toBeDefined();
+    expect(pageview.url).toEqual(window.location.href);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export function initialize(env, user, options = {}) {
   client.waitUntilGoalsReady = () => goalsPromise;
 
   if (validatedOptions.fetchGoals) {
-    GoalManager(clientVars, () => emitter.emit(goalsEvent));
+    GoalManager(clientVars, platform, () => emitter.emit(goalsEvent));
     // Don't need to save a reference to the GoalManager - its constructor takes care of setting
     // up the necessary event wiring
   } else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small behavioral fix aligning goal URLs with other events; covered by new tests with no auth or data-model changes.
> 
> **Overview**
> Goal conversion events (`pageview`, `click_pageview`, etc.) now take their `url` from `platform.getCurrentUrl()` instead of `window.location.href`, so the optional `eventUrlTransformer` applies to goal traffic the same way it already does for `track()` and other SDK events.
> 
> `GoalManager` accepts a `platform` argument; `initialize` passes the existing `browserPlatform` instance. New unit tests cover transformed and untransformed goal event URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aba6fd28a04ef1879edd663a97b3c90dcae21dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->