### PR TITLE
fix: update launchdarkly-js-sdk-common to 5.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "sinon": "^14.0.0",
     "typescript": "~5.4.5",
     "typedoc": "^0.25.13",
-    "@types/estree": "^1.0.0"
+    "@types/estree": "^1.0.0",
+    "@types/node": "^20.0.0"
   },
   "dependencies": {
     "escape-string-regexp": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "escape-string-regexp": "^4.0.0",
-    "launchdarkly-js-sdk-common": "5.8.1"
+    "launchdarkly-js-sdk-common": "5.8.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality — n/a, dependency bump only
- [x] I have followed the repository's pull request submission guidelines
- [x] I have validated my changes against all supported platform versions

**Related issues**

Picks up the bugfix released in `launchdarkly-js-sdk-common` v5.8.2 (https://github.com/launchdarkly/js-sdk-common).

**Describe the solution you've provided**

Bump the `launchdarkly-js-sdk-common` dependency from `5.8.1` to `5.8.2`.

```diff
-    "launchdarkly-js-sdk-common": "5.8.1"
+    "launchdarkly-js-sdk-common": "5.8.2"
```

Uses `fix:` (matching #341) so release-please cuts a patch release that propagates the fix to downstream consumers.

Also pins `@types/node` to `^20.0.0`. `@types/node` was previously unpinned (pulled transitively) and had floated to v26, which references lib types (`IteratorObject`, `BuiltinIteratorReturn`) that don't exist in `typescript ~5.4.5`, breaking `npm run check-typescript`. This failure already exists on `main` (verified on a clean checkout) and is unrelated to the common bump; the pin is the minimal fix to get `check-typescript` / CI green again.

Verified locally: `npm install`, `npm test` (166 passed), `npm run lint:all`, and `npm run check-typescript` all pass.

**Describe alternatives you've considered**

For the type errors, `skipLibCheck` in tsconfig would also silence them, but pinning `@types/node` to a version compatible with the pinned TypeScript is more targeted.

**Additional context**

Part of rolling out `launchdarkly-js-sdk-common` v5.8.2 across the client-side JS SDKs (companion PR in `node-client-sdk`). Downstream packages that depend on this SDK (`react-client-sdk`, `vue-client-sdk`, `@launchdarkly/toolbar`) will pick up the change transitively once this SDK is released.

Link to Devin session: https://app.devin.ai/sessions/3ed6e570c11b4abb80724e0f2bc5f03e
Requested by: @joker23

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only changes with no application logic edits; risk is limited to transitive behavior from the common SDK patch and dev-time typing.
> 
> **Overview**
> Pulls in the **5.8.2** patch from `launchdarkly-js-sdk-common` (replacing **5.8.1**) so this browser SDK ships the upstream bugfix on the next patch release.
> 
> Adds an explicit devDependency **`@types/node`: `^20.0.0`** so `check-typescript` no longer fails when an unpinned transitive `@types/node` (e.g. v26) references lib types that **TypeScript ~5.4.5** does not provide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca4b27ae549362625267c1a15484275b661a9c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->